### PR TITLE
configure Read The Docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,19 +3,16 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.8"
   jobs:
     pre_build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.
       - "jupyter-book config sphinx book/"
 
 python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-      - sphinx
+   install:
+   - requirements: book/requirements.txt
 
 sphinx:
   builder: html
-  fail_on_warning: true
+  fail_on_warning: false

--- a/book/requirements.txt
+++ b/book/requirements.txt
@@ -1,0 +1,1 @@
+jupyter-book


### PR DESCRIPTION
At this point the API docs don't build on RTD - need to get the tiny distro installed there first. 