### PR TITLE
HTML: expand first level of sidebar automatically

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -20,6 +20,7 @@ sphinx:
       logo:
         image_light: _static/dwq2-light.png
         image_dark: _static/dwq2-dark.png
+      show_navbar_depth: 2
 
 execute:
   execute_notebooks: force


### PR DESCRIPTION
It's a little easier to orient yourself with the subsections expanded by 1.

(Will we see a preview of this on readthedocs?)